### PR TITLE
Fix default limit of 500

### DIFF
--- a/wiki.py
+++ b/wiki.py
@@ -33,10 +33,6 @@ class WikiClient():
         Returns:
             list(str): The titles of pages that backlink to `title`
         """
-        # The largest batch size allowed by WikiData is 500
-        # Ensure our limit is less than that.        
-        if not limit or limit > 500:
-            limit = 500
         if not isinstance(limit, int) or limit < 1:
             raise ValueError(limit)
         # EP: at this point limit is int type and likely has value 5000  


### PR DESCRIPTION
Fixes an error in the limit logic. Any limit greater than 500 was getting set to 500 and so, all pages could never be returned.